### PR TITLE
Handles currentStudent and currentCohort, DRYs Material-Ui and Organizes Routes

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -69,7 +69,7 @@ export function fetchClassroomListSucceded(classroomList) {
     return {
     type: GET_CLASSROOM_LIST_SUCCEDED,
         payload: {
-            classroomList
+            classroomList,
         }
     }
 }

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -15,7 +15,7 @@ export function fetchClassroomList() {
 
 export function fetchCohortList() {
     // TODO: Change to cohortsapi when we have Cohort table in back-end
-    return client.get('classroomsapi');
+    return client.get('cohortsapi');
 }
 
 export function fetchAssignmentList() {

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -14,7 +14,7 @@ export function fetchClassroomList() {
 }
 
 export function fetchCohortList() {
-    // Change to cohortsapi when we have Cohort table in back-end
+    // TODO: Change to cohortsapi when we have Cohort table in back-end
     return client.get('classroomsapi');
 }
 

--- a/src/components-info/MaterialUiImports.js
+++ b/src/components-info/MaterialUiImports.js
@@ -1,0 +1,66 @@
+// For MiniDrawer
+export {default as Drawer} from '@material-ui/core/Drawer';
+export {default as AppBar} from '@material-ui/core/AppBar';
+export {default as Toolbar} from '@material-ui/core/Toolbar';
+export {default as Typography} from '@material-ui/core/Typography';
+export {default as Divider} from '@material-ui/core/Divider';
+export {default as IconButton} from '@material-ui/core/IconButton';
+export {default as MenuIcon} from '@material-ui/icons/Menu';
+export {default as ChevronLeftIcon} from '@material-ui/icons/ChevronLeft';
+
+// For Assignments and StudentsList
+export {default as Table} from '@material-ui/core/Table';
+export {default as TableBody} from '@material-ui/core/TableBody';
+export {default as TableCell} from '@material-ui/core/TableCell';
+export {default as TableHead} from '@material-ui/core/TableHead';
+export {default as TableRow} from '@material-ui/core/TableRow';
+export {default as Paper} from '@material-ui/core/Paper';
+
+// For Classroom and Cohort
+
+export {default as InputLabel} from '@material-ui/core/InputLabel';
+export {default as MenuItem} from '@material-ui/core/MenuItem';
+export {default as FormControl} from '@material-ui/core/FormControl';
+export {default as Select} from '@material-ui/core/Select';
+
+//  For LinksList
+export {default as BookIcon} from '@material-ui/icons/Book';
+export {default as HomeIcon} from '@material-ui/icons/Home';
+export {default as CheckIcon} from '@material-ui/icons/Done';
+
+// For LisItemLink
+export {default as ListItem} from '@material-ui/core/ListItem';
+export {default as ListItemIcon} from '@material-ui/core/ListItemIcon';
+export {default as ListItemText} from '@material-ui/core/ListItemText';
+
+//  For MarkdownFeedBack
+export {default as MarkdownElement} from "@material-ui/docs/MarkdownElement";
+// export {default as Paper} from '@material-ui/core/Paper';
+export {default as Grid} from '@material-ui/core/Grid';
+export {default as Card} from "@material-ui/core/es/Card";
+// export {default as GridContainer} from "@material-ui/core/Grid";
+export {default as CardHeader} from "@material-ui/core/CardHeader/CardHeader";
+export {default as CardContent} from "@material-ui/core/CardContent";
+export {default as Input} from "@material-ui/core/Input";
+// export {default as Typography} from "@material-ui/core/es/Typography/Typography";
+export {default as CodeIcon} from "@material-ui/icons/es/Code";
+export {default as Avatar} from "@material-ui/core/es/Avatar/Avatar";
+// export {default as FormGroup} from "@material-ui/core/es/FormGroup/FormGroup";
+// export {default as FormControlLabel} from "@material-ui/core/es/FormControlLabel/FormControlLabel";
+// export {default as Switch} from "@material-ui/core/es/Switch/Switch";
+// export {default as List} from "@material-ui/core/es/List/List";
+// export {default as ListItem} from "@material-ui/core/es/ListItem/ListItem"; --> REPEATED
+
+//  For Repo
+// export {default as TableCell} from '@material-ui/core/TableCell'; --> REPEATED
+// export {default as TableRow} from '@material-ui/core/TableRow'; --> REPEATED
+
+// For Student
+// export {default as TableCell} from '@material-ui/core/TableCell'; --> REPEATED
+// export {default as TableRow} from '@material-ui/core/TableRow'; --> REPEATED
+export {default as Button} from '@material-ui/core/Button';
+export {default as Dialog} from '@material-ui/core/Dialog';
+export {default as DialogActions} from '@material-ui/core/DialogActions';
+export {default as DialogContent} from '@material-ui/core/DialogContent';
+export {default as DialogContentText} from '@material-ui/core/DialogContentText';
+export {default as DialogTitle} from '@material-ui/core/DialogTitle';

--- a/src/components/AssignmentList.js
+++ b/src/components/AssignmentList.js
@@ -7,12 +7,14 @@ import {bindActionCreators} from 'redux';
 import {fetchAssignmentList} from '../actions';
 
 // For Styles:
-import Table from '@material-ui/core/Table';
-import TableBody from '@material-ui/core/TableBody';
-import TableCell from '@material-ui/core/TableCell';
-import TableHead from '@material-ui/core/TableHead';
-import TableRow from '@material-ui/core/TableRow';
-import Paper from '@material-ui/core/Paper';
+ import { 
+  Table, 
+  TableBody , 
+  TableCell , 
+  TableHead , 
+  TableRow , 
+  Paper 
+} from '../components-info/MaterialUiImports'
 
 class AssignmentList extends Component {
 

--- a/src/components/Classroom.js
+++ b/src/components/Classroom.js
@@ -1,13 +1,15 @@
 import React, { Component } from 'react';
 
-import InputLabel from '@material-ui/core/InputLabel';
-import MenuItem from '@material-ui/core/MenuItem';
-import FormControl from '@material-ui/core/FormControl';
-import Select from '@material-ui/core/Select';
-
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import {changeClassroom} from '../actions';
+
+ import { InputLabel, 
+ MenuItem, 
+ FormControl, 
+ Select
+} from '../components-info/MaterialUiImports'
+
 
 class Classroom extends Component {
 

--- a/src/components/Classroom.js
+++ b/src/components/Classroom.js
@@ -17,7 +17,7 @@ class Classroom extends Component {
     console.log(this.props.classroomList)
     return this.props.classroomList.map((classroom, index) => {
        return (
-       <MenuItem key={index} value={classroom.id}> {classroom.name} </MenuItem>
+       <MenuItem key={index} value={[classroom.id, classroom.name]}> {classroom.name} </MenuItem>
        );
    });
 }
@@ -28,19 +28,20 @@ class Classroom extends Component {
   };
 
   render() {
-    console.log('classroom: ' + this.props.classroom)
+    console.log('classroom: ' )
+    console.log(this.props.classroomName)
 
-    const classroom = this.props.classroom;
-
+    const classroomName = this.props.classroomName;
+   
     return (
    
       <section style={{textAlign:"center"}}>
         <div>Classroom</div>
           <form  autoComplete="off">
         <FormControl >
-          <InputLabel htmlFor="change-classroom"></InputLabel>
+          <InputLabel htmlFor="change-classroom">{classroomName}</InputLabel>
           <Select
-            value={classroom}
+            value={classroomName}
             onChange={this.handleChange}
             inputProps={{
               name: 'classroom',
@@ -59,10 +60,10 @@ class Classroom extends Component {
 
 function mapStateToProps(state) {
   console.log('function mapStateToProps:' )
-  console.log(state.classroom)
-    console.log(state.classroomList)
+  console.log(state)
     return {
-    classroom: state.classroom,
+    classroomId: state.currentClassroomId,
+    classroomName: state.currentClassroomName,
     classroomList: state.classroomList
     }
 }

--- a/src/components/Cohort.js
+++ b/src/components/Cohort.js
@@ -1,13 +1,15 @@
 import React, { Component } from 'react';
 
-import InputLabel from '@material-ui/core/InputLabel';
-import MenuItem from '@material-ui/core/MenuItem';
-import FormControl from '@material-ui/core/FormControl';
-import Select from '@material-ui/core/Select';
-
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import {changeCohort} from '../actions';
+
+import { InputLabel, 
+  MenuItem, 
+  FormControl, 
+  Select
+ } from '../components-info/MaterialUiImports'
+ 
 
 class Cohort extends Component {
 

--- a/src/components/LinksList.js
+++ b/src/components/LinksList.js
@@ -1,0 +1,25 @@
+import React, { Component } from 'react';
+import ListItemLink from './ListItemLink'
+import BookIcon from '@material-ui/icons/Book';
+import HomeIcon from '@material-ui/icons/Home';
+// import AllInclusive from '@material-ui/icons/Home'
+import CheckIcon from '@material-ui/icons/Done';
+// import SchoolIcon from '@material-ui/icons/School';
+
+class LinksList extends Component {
+
+  render() {
+    return (
+    
+      <div>
+        <ListItemLink to="/lovelace-front-end" primary="LandingPage" icon={<HomeIcon />} />
+        <ListItemLink to="/lovelace-front-end/homepage" primary="Homepage" icon={<HomeIcon />} />
+        <ListItemLink to="/lovelace-front-end/feedback" primary="Feedback" icon={<CheckIcon />} />
+        <ListItemLink to="/lovelace-front-end/assignments" primary="Assignments" icon={<BookIcon />} />
+        <ListItemLink to="/lovelace-front-end/students" primary="StudentsList" icon={<BookIcon />} />
+      </div>
+    );
+  }
+}
+
+export default LinksList;

--- a/src/components/LinksList.js
+++ b/src/components/LinksList.js
@@ -1,10 +1,11 @@
 import React, { Component } from 'react';
 import ListItemLink from './ListItemLink'
-import BookIcon from '@material-ui/icons/Book';
-import HomeIcon from '@material-ui/icons/Home';
-// import AllInclusive from '@material-ui/icons/Home'
-import CheckIcon from '@material-ui/icons/Done';
-// import SchoolIcon from '@material-ui/icons/School';
+
+import { 
+    BookIcon, 
+    HomeIcon, 
+    CheckIcon, 
+} from '../components-info/MaterialUiImports'
 
 class LinksList extends Component {
 

--- a/src/components/ListItemLink.js
+++ b/src/components/ListItemLink.js
@@ -1,9 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import ListItem from '@material-ui/core/ListItem';
-import ListItemIcon from '@material-ui/core/ListItemIcon';
-import ListItemText from '@material-ui/core/ListItemText';
 import { Link } from 'react-router-dom';
+
+ import { 
+  ListItem,
+  ListItemIcon, 
+  ListItemText, 
+} from '../components-info/MaterialUiImports'
 
 
 class ListItemLink extends React.Component {

--- a/src/components/MarkdownFeedback.js
+++ b/src/components/MarkdownFeedback.js
@@ -1,23 +1,25 @@
 import React, { Component } from 'react';
-// import ReactMarkdown from "react-markdown"; TODO: figure out how to uninstall
-import MarkdownElement from "@material-ui/docs/MarkdownElement";
-// import PropTypes from 'prop-types';
-// import Paper from '@material-ui/core/Paper';
-import Grid from '@material-ui/core/Grid';
-import Card from "@material-ui/core/es/Card";
-// import GridContainer from "@material-ui/core/Grid";
-import CardHeader from "@material-ui/core/CardHeader/CardHeader";
-import CardContent from "@material-ui/core/CardContent";
-import Input from "@material-ui/core/Input";
-// import Typography from "@material-ui/core/es/Typography/Typography";
-import CodeIcon from "@material-ui/icons/es/Code";
-import Avatar from "@material-ui/core/es/Avatar/Avatar";
-// import FormGroup from "@material-ui/core/es/FormGroup/FormGroup";
-// import FormControlLabel from "@material-ui/core/es/FormControlLabel/FormControlLabel";
-// import Switch from "@material-ui/core/es/Switch/Switch";
 import axios from 'axios';
-// import List from "@material-ui/core/es/List/List";
-import ListItem from "@material-ui/core/es/ListItem/ListItem";
+// import PropTypes from 'prop-types';
+import {
+//  ReactMarkdown,
+ MarkdownElement, 
+//  Paper, 
+ Grid, 
+ Card,
+//  GridContainer,
+ CardHeader,
+ CardContent, 
+ Input,
+//  Typography, 
+ CodeIcon, 
+ Avatar, 
+//  FormGroup, 
+//  FormControlLabel, 
+//  Switch,
+//  List, 
+ ListItem,
+} from '../components-info/MaterialUiImports'
 
 let initialSourcetwo = '# Task List\r\n## What We\'re Looking For\r\n\r\nFeature | Feedback\r\n:------------- | :-------------\r\n**Baseline** | \r\nAppropriate Git Usage with no extraneous files checked in | Good number of commits and commit messages\r\nAnswered comprehension questions | Check, Strong Params actually ensure that no unexpected fields are inserted in creation or update operations.  Familiarity with routes & styling will come with practice.  If you have a specific question, send it on to me.  \r\nSuccessfully handles: Index, Show | Check\r\nSuccessfully handles: New, Create | Check.\r\nSuccessfully handles: Edit, Update | Check\r\nSuccessfully handles: Destroy, Task Complete | Check\r\nRoutes follow RESTful conventions | Check\r\nUses named routes (like `_path`) | Check\r\nUses partial views to DRY the new and edit forms | Check\r\n**Overall** | Nicely done.  The site works and does everything expected.  The styling looks good without being too fancy. \r\n';
 

--- a/src/components/MiniDrawer.js
+++ b/src/components/MiniDrawer.js
@@ -2,16 +2,26 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { withStyles } from '@material-ui/core/styles';
-import Drawer from '@material-ui/core/Drawer';
-import AppBar from '@material-ui/core/AppBar';
-import Toolbar from '@material-ui/core/Toolbar';
-import Typography from '@material-ui/core/Typography';
-import Divider from '@material-ui/core/Divider';
-import IconButton from '@material-ui/core/IconButton';
-import MenuIcon from '@material-ui/icons/Menu';
-import ChevronLeftIcon from '@material-ui/icons/ChevronLeft';
 import LinksList from './LinksList'
+// import Drawer from '@material-ui/core/Drawer';
+// import AppBar from '@material-ui/core/AppBar';
+// import Toolbar from '@material-ui/core/Toolbar';
+// import Typography from '@material-ui/core/Typography';
+// import Divider from '@material-ui/core/Divider';
+// import IconButton from '@material-ui/core/IconButton';
+// import MenuIcon from '@material-ui/icons/Menu';
+// import ChevronLeftIcon from '@material-ui/icons/ChevronLeft';
 
+import {
+Drawer, 
+AppBar,
+Toolbar, 
+Typography, 
+Divider,
+IconButton, 
+MenuIcon,
+ChevronLeftIcon, 
+} from '../components-info/MaterialUiImports'
 
 const drawerWidth = 240;
 
@@ -101,7 +111,6 @@ class MiniDrawer extends React.Component {
   };
 
 
-
   render() {
     const { classes } = this.props;
 
@@ -135,16 +144,13 @@ class MiniDrawer extends React.Component {
           <section style={{backgroundColor: "#669933"}} className={classes.toolbar}>
             <IconButton onClick={this.handleDrawerClose}><ChevronLeftIcon style={{color: "white"}}/></IconButton>
           </section>
-
           <Divider />
-          
+          {/* Render list of links on side bar: */}
           <LinksList />
-          
         </Drawer>
         <main className={classes.content}>
           <div className={classes.toolbar}/>
           <section height="100vh" overflow="scroll">{this.props.children}</section>
-
         </main>
       </div>
     );

--- a/src/components/MiniDrawer.js
+++ b/src/components/MiniDrawer.js
@@ -2,15 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { withStyles } from '@material-ui/core/styles';
-import LinksList from './LinksList'
-// import Drawer from '@material-ui/core/Drawer';
-// import AppBar from '@material-ui/core/AppBar';
-// import Toolbar from '@material-ui/core/Toolbar';
-// import Typography from '@material-ui/core/Typography';
-// import Divider from '@material-ui/core/Divider';
-// import IconButton from '@material-ui/core/IconButton';
-// import MenuIcon from '@material-ui/icons/Menu';
-// import ChevronLeftIcon from '@material-ui/icons/ChevronLeft';
+import SidebarInstructorsLinksList from '../routes/SidebarInstructorsLinksList'
+import SidebarStudentsLinksList from '../routes/SidebarStudentsLinksList'
 
 import {
 Drawer, 
@@ -145,8 +138,9 @@ class MiniDrawer extends React.Component {
             <IconButton onClick={this.handleDrawerClose}><ChevronLeftIcon style={{color: "white"}}/></IconButton>
           </section>
           <Divider />
-          {/* Render list of links on side bar: */}
-          <LinksList />
+          {/* Render list of links on side bar. Changes wich one to render using permission once login is set up*/}
+          <SidebarInstructorsLinksList />
+          <SidebarStudentsLinksList />
         </Drawer>
         <main className={classes.content}>
           <div className={classes.toolbar}/>

--- a/src/components/MiniDrawer.js
+++ b/src/components/MiniDrawer.js
@@ -10,12 +10,8 @@ import Divider from '@material-ui/core/Divider';
 import IconButton from '@material-ui/core/IconButton';
 import MenuIcon from '@material-ui/icons/Menu';
 import ChevronLeftIcon from '@material-ui/icons/ChevronLeft';
-import ListItemLink from './ListItemLink'
-import BookIcon from '@material-ui/icons/Book';
-import HomeIcon from '@material-ui/icons/Home';
-// import AllInclusive from '@material-ui/icons/Home'
-import CheckIcon from '@material-ui/icons/Done';
-// import SchoolIcon from '@material-ui/icons/School';
+import LinksList from './LinksList'
+
 
 const drawerWidth = 240;
 
@@ -141,13 +137,9 @@ class MiniDrawer extends React.Component {
           </section>
 
           <Divider />
-          {/* <ul> */}
-            <ListItemLink to="/lovelace-front-end" primary="LandingPage" icon={<HomeIcon />} />
-            <ListItemLink to="/lovelace-front-end/homepage" primary="Homepage" icon={<HomeIcon />} />
-            <ListItemLink to="/lovelace-front-end/feedback" primary="Feedback" icon={<CheckIcon />} />
-            <ListItemLink to="/lovelace-front-end/assignments" primary="Assignments" icon={<BookIcon />} />
-            <ListItemLink to="/lovelace-front-end/students" primary="StudentsList" icon={<BookIcon />} />
-          {/* </ul> */}
+          
+          <LinksList />
+          
         </Drawer>
         <main className={classes.content}>
           <div className={classes.toolbar}/>

--- a/src/components/Student.js
+++ b/src/components/Student.js
@@ -2,15 +2,17 @@ import React, { Component } from 'react';
 // import PropTypes from 'prop-types';
 
 // For Styles:
-import TableCell from '@material-ui/core/TableCell';
-import TableRow from '@material-ui/core/TableRow';
+ import { 
+ TableCell,
+ TableRow, 
+ Button, 
+ Dialog, 
+ DialogActions,
+ DialogContent, 
+ DialogContentText,
+ DialogTitle,
+} from '../components-info/MaterialUiImports'
 
-import Button from '@material-ui/core/Button';
-import Dialog from '@material-ui/core/Dialog';
-import DialogActions from '@material-ui/core/DialogActions';
-import DialogContent from '@material-ui/core/DialogContent';
-import DialogContentText from '@material-ui/core/DialogContentText';
-import DialogTitle from '@material-ui/core/DialogTitle';
 
 class Student extends Component {
 

--- a/src/components/Student.js
+++ b/src/components/Student.js
@@ -37,7 +37,7 @@ class Student extends Component {
         <TableCell onClick={this.handleClickOpen('paper')}>{this.props.classroom}</TableCell>
         <TableCell onClick={this.handleClickOpen('paper')}>{this.props.githubName}</TableCell>
         <TableCell onClick={this.handleClickOpen('paper')}>{this.props.email}</TableCell>
-          {/* Figure out how to DRY this to tablerow onclick insetad of tablecell without loosing format */}
+        {/* Figure out how to DRY this to tablerow onclick insetad of tablecell without loosing format */}
 
 
         {/* For the pop-up dialog box: */}

--- a/src/components/Student.js
+++ b/src/components/Student.js
@@ -5,18 +5,71 @@ import React, { Component } from 'react';
 import TableCell from '@material-ui/core/TableCell';
 import TableRow from '@material-ui/core/TableRow';
 
+import Button from '@material-ui/core/Button';
+import Dialog from '@material-ui/core/Dialog';
+import DialogActions from '@material-ui/core/DialogActions';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogContentText from '@material-ui/core/DialogContentText';
+import DialogTitle from '@material-ui/core/DialogTitle';
 
 class Student extends Component {
+
+
+  state = {
+    open: false,
+    scroll: 'paper',
+  };
+
+  handleClickOpen = scroll => () => {
+    this.setState({ open: true, scroll });
+  };
+
+  handleClose = () => {
+    this.setState({ open: false });
+  };
+
 
   render() {
     return (
       <TableRow>
-        <TableCell onClick={this.props.onClick}> {this.props.name}</TableCell>
-        <TableCell> Put Cohort </TableCell> 
-        <TableCell>{this.props.classroom}</TableCell>
-        <TableCell>{this.props.githubName}</TableCell>
-        <TableCell>{this.props.email}</TableCell>
-      </TableRow>
+        <TableCell onClick={this.handleClickOpen('paper')}>{this.props.name}</TableCell>
+        <TableCell onClick={this.handleClickOpen('paper')}>Put Cohort </TableCell> 
+        <TableCell onClick={this.handleClickOpen('paper')}>{this.props.classroom}</TableCell>
+        <TableCell onClick={this.handleClickOpen('paper')}>{this.props.githubName}</TableCell>
+        <TableCell onClick={this.handleClickOpen('paper')}>{this.props.email}</TableCell>
+          {/* Figure out how to DRY this to tablerow onclick insetad of tablecell without loosing format */}
+
+
+        {/* For the pop-up dialog box: */}
+        <Dialog
+          open={this.state.open}
+          onClose={this.handleClose}
+          scroll={this.state.scroll}
+          aria-labelledby="scroll-dialog-title"
+        >
+          <DialogTitle id="scroll-dialog-title">{this.props.name}</DialogTitle>
+          <DialogContent>
+            <DialogContentText>
+              put github picture?
+              <p><strong>Cohort: </strong>Put Cohort</p>
+              <p><strong>Classroom: </strong>{this.props.classroom}</p>
+              <p><strong>GitHub name: </strong>{this.props.githubName}</p>
+              <p><strong>Email: </strong>{this.props.email}</p>
+            </DialogContentText>
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={this.props.openGitHubProfile} color="primary">
+              See GitHub Page
+            </Button>
+            <Button onClick={this.handleClose} color="primary">
+              Close
+            </Button>
+          </DialogActions>
+        </Dialog>
+        
+        </TableRow>
+
+       
     )
   }
 }

--- a/src/components/StudentsList.js
+++ b/src/components/StudentsList.js
@@ -19,7 +19,6 @@ import {
 } from '../components-info/MaterialUiImports'
 
 
-
 class StudentsList extends Component {
 
     componentDidMount() {

--- a/src/components/StudentsList.js
+++ b/src/components/StudentsList.js
@@ -8,13 +8,15 @@ import {bindActionCreators} from 'redux';
 import {fetchStudentsList} from '../actions';
 
 // For Styles:
-import Table from '@material-ui/core/Table';
-import TableBody from '@material-ui/core/TableBody';
-import TableCell from '@material-ui/core/TableCell';
-import TableHead from '@material-ui/core/TableHead';
-import TableRow from '@material-ui/core/TableRow';
-import Paper from '@material-ui/core/Paper';
-import Typography from '@material-ui/core/Typography';
+import { 
+  Table, 
+  TableBody, 
+  TableCell, 
+  TableHead, 
+  TableRow, 
+  Paper,
+  Typography 
+} from '../components-info/MaterialUiImports'
 
 
 

--- a/src/components/StudentsList.js
+++ b/src/components/StudentsList.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 // import PropTypes from 'prop-types';
-import Student from '../components/Student.js'
+import Student from './Student.js'
 
 // For Redux:
 import {connect} from 'react-redux';

--- a/src/components/login.js
+++ b/src/components/login.js
@@ -1,7 +1,5 @@
 import React, { Component } from 'react';
 // import PropTypes from 'prop-types';
-// import LinkToButton from './LinkToButton.js'
-// import indexRoutes from '../routes/index.js'
 import Button from '@material-ui/core/Button';
 
 class Login extends Component {

--- a/src/components/repo.js
+++ b/src/components/repo.js
@@ -1,8 +1,10 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
-import TableCell from '@material-ui/core/TableCell';
-import TableRow from '@material-ui/core/TableRow';
+import { 
+ TableCell,
+ TableRow
+} from '../components-info/MaterialUiImports'
 
 class Repo extends Component {
 

--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,7 @@ import {
 // creating store with thunk to be able to fetch cohort and classrooms on componentDidMount in:
 const store = createStore(
     rootReducer,
+    window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__(),
     applyMiddleware(thunk)
 )
 

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -9,10 +9,10 @@ import {GET_ASSIGNMENTS_LIST_SUCCEDED} from '../actions';
 import {GET_STUDENTS_LIST_SUCCEDED} from '../actions';
 
 const stateList = {
-    cohort: 1, 
+    cohort: "Select", 
     cohortList: [], 
-    currentClassroomName: "Jelly", 
-    currentClassroomId: 1,
+    currentClassroomName: "Select", 
+    currentClassroomId: "Select",
     classroomList: [],
     assignmentList: [],
     studentsList: [],
@@ -34,8 +34,20 @@ const stateList = {
         console.log("GET_COHORT_LIST_SUCCEDED called");
         console.log(state, action)
         console.log(action.payload.cohortList)
+
+        let selectCohort = state.cohort
+        let cohortList = action.payload.cohortList
+        let cohortListSize = action.payload.cohortList.length-1
+
+        if(state.cohort === "Select")  {
+            selectCohort = cohortList[cohortListSize].id
+        }
+        // Can't use .pop() here! TODO: refactor all this variables..... 
+
+
         return Object.assign({}, state, {
-            cohortList : action.payload.cohortList
+            cohortList : action.payload.cohortList,
+            cohort: selectCohort
         })
 
 
@@ -54,8 +66,23 @@ const stateList = {
         console.log("GET_CLASSROOM_LIST_SUCCEDED called");
         console.log(state, action)
         console.log(action.payload.classroomList)
+        console.log(action.payload.classroomList.last)
+
+        let assignClassroomId = state.currentClassroomId 
+        let assignClassroomName = state.classroomcurrentClassroomName
+        let classroomList = action.payload.classroomList
+        let classroomListSize = action.payload.classroomList.length-1
+
+        if(state.currentClassroomId === "Select" || state.currentClassroomName === "Select")  {
+             assignClassroomId = classroomList[classroomListSize].id
+             assignClassroomName = classroomList[classroomListSize].name
+        }
+        // Can't use .pop() here! TODO: refactor all this variables..... 
+
         return Object.assign({}, state, {
-            classroomList : action.payload.classroomList
+            classroomList : classroomList,
+            currentClassroomId: assignClassroomId,
+            currentClassroomName: assignClassroomName
         })
         
 

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -11,7 +11,8 @@ import {GET_STUDENTS_LIST_SUCCEDED} from '../actions';
 const stateList = {
     cohort: 1, 
     cohortList: [], 
-    classroom: 1, 
+    currentClassroomName: "Jelly", 
+    currentClassroomId: 1,
     classroomList: [],
     assignmentList: [],
     studentsList: [],
@@ -41,9 +42,12 @@ const stateList = {
         // *********** CLASSROOM *****************
         case CHANGE_CLASSROOM:
         console.log("CHANGE_CLASSROOM called");
-        console.log(state, action)
+        console.log(state)
+        console.log("action:")
+        console.log(action)
         return Object.assign({}, state, {
-            classroom : action.classroom
+            currentClassroomName : action.classroom[1],
+            currentClassroomId: action.classroom[0]
         })
 
         case GET_CLASSROOM_LIST_SUCCEDED:
@@ -73,9 +77,9 @@ const stateList = {
 
          // Filter students in current classromm
          const studentsInCurrentClassrom = action.payload.studentsList.filter((student) => {
-            console.log("state.classroom")
-            console.log(state.classroom)
-            return student.classroom_id === state.classroom
+            console.log("state.currentClassroomName")
+            console.log(state.currentClassroomName)
+            return student.classroom_id === state.currentClassroomId
         })
 
         console.log(studentsInCurrentClassrom)

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -14,7 +14,8 @@ const stateList = {
     classroom: 1, 
     classroomList: [],
     assignmentList: [],
-    studentsList: []
+    studentsList: [],
+    currentClassroomStudents: []
 }
 
  function performAction(state = stateList, action) {
@@ -35,6 +36,7 @@ const stateList = {
         return Object.assign({}, state, {
             cohortList : action.payload.cohortList
         })
+
 
         // *********** CLASSROOM *****************
         case CHANGE_CLASSROOM:
@@ -68,9 +70,28 @@ const stateList = {
          console.log("GET_STUDENTS_LIST_SUCCEDED called");
          console.log(state, action)
          console.log(action.payload.studentsList)
+
+         // Filter students in current classromm
+         const studentsInCurrentClassrom = action.payload.studentsList.filter((student) => {
+            console.log("state.classroom")
+            console.log(state.classroom)
+            return student.classroom_id === state.classroom
+        })
+
+        console.log(studentsInCurrentClassrom)
+        // Change state:
          return Object.assign({}, state, {
-             studentsList : action.payload.studentsList
+             studentsList : action.payload.studentsList,
+             currentClassroomStudents: studentsInCurrentClassrom
          })
+
+        //  case POPULATES_COHORT_STUDENTS_LIST:
+        //     return Object.assign({}, state, {
+            // currentClassroomStudents: action.payload.studentsList.filter((student) => {
+            //     return student.classroom_id === cohort
+            // })
+        //     });
+
 
         default:
         return state

--- a/src/routes/SidebarInstructorsLinksList.js
+++ b/src/routes/SidebarInstructorsLinksList.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import ListItemLink from './ListItemLink'
+import ListItemLink from '../components/ListItemLink'
 
 import { 
     BookIcon, 
@@ -7,14 +7,14 @@ import {
     CheckIcon, 
 } from '../components-info/MaterialUiImports'
 
-class LinksList extends Component {
+class SidebarInstructorsLinksList extends Component {
 
   render() {
     return (
     
       <div>
         <ListItemLink to="/lovelace-front-end" primary="LandingPage" icon={<HomeIcon />} />
-        <ListItemLink to="/lovelace-front-end/homepage" primary="Homepage" icon={<HomeIcon />} />
+        <ListItemLink to="/lovelace-front-end/homepage" primary="Instructors Homepage" icon={<HomeIcon />} />
         <ListItemLink to="/lovelace-front-end/feedback" primary="Feedback" icon={<CheckIcon />} />
         <ListItemLink to="/lovelace-front-end/assignments" primary="Assignments" icon={<BookIcon />} />
         <ListItemLink to="/lovelace-front-end/students" primary="StudentsList" icon={<BookIcon />} />
@@ -23,4 +23,4 @@ class LinksList extends Component {
   }
 }
 
-export default LinksList;
+export default SidebarInstructorsLinksList;

--- a/src/routes/SidebarStudentsLinksList.js
+++ b/src/routes/SidebarStudentsLinksList.js
@@ -1,0 +1,24 @@
+import React, { Component } from 'react';
+import ListItemLink from '../components/ListItemLink'
+
+import { 
+    BookIcon, 
+    HomeIcon, 
+    CheckIcon, 
+} from '../components-info/MaterialUiImports'
+
+class SidebarStudentsLinksList extends Component {
+
+  render() {
+    return (
+      <div>
+        {/* <ListItemLink to="/lovelace-front-end" primary="LandingPage" icon={<HomeIcon />} /> */}
+        {/* <ListItemLink to="/lovelace-front-end/homepage" primary="Homepage" icon={<HomeIcon />} /> */}
+        {/* <ListItemLink to="/lovelace-front-end/classmates" primary="Classmates" icon={<CheckIcon />} /> */}
+        {/* <ListItemLink to="/lovelace-front-end/assignments" primary="Assignments" icon={<BookIcon />} /> */}
+      </div>
+    );
+  }
+}
+
+export default SidebarStudentsLinksList;

--- a/src/routes/index.jsx
+++ b/src/routes/index.jsx
@@ -3,14 +3,16 @@ import Assignments from '../views/Instructors/Assignments.js';
 import Homepage from '../views/Instructors/Homepage.jsx';
 import Feedback from '../views/Instructors/Feedback.js';
 import StudentsList from '../components/StudentsList.js';
+// import Classmates from '../views/Students/Classmates.js';
+
 
 
 let indexRoutes = [
   { path: "/lovelace-front-end/assignments", name: "Assignments", component: Assignments },
-  { path: "/lovelace-front-end/homepage", name: "Homepage", component: Homepage },
+  { path: "/lovelace-front-end/homepage", name: "Instructors Homepage", component: Homepage },
   { path: "/lovelace-front-end/feedback", name: "Feedback", component: Feedback },
   { path: "/lovelace-front-end/students", name: "StudentsList", component: StudentsList },
-  // { path: "/lovelace-front-end/students/", name: "StudentProfile", component: StudentsList },
+  // { path: "/lovelace-front-end/classmates/", name: "Classmates", component: Classmates },
   { path: "/lovelace-front-end", name: "LandingPage", component: LandingPage }
   ];
 

--- a/src/routes/index.jsx
+++ b/src/routes/index.jsx
@@ -1,8 +1,8 @@
 import LandingPage from '../views/LandingPage.js';
-import Assignments from '../views/Assignments.js';
-import Homepage from '../views/Homepage.jsx';
-import Feedback from '../views/Feedback.js';
-import StudentsList from '../views/StudentsList.js';
+import Assignments from '../views/Instructors/Assignments.js';
+import Homepage from '../views/Instructors/Homepage.jsx';
+import Feedback from '../views/Instructors/Feedback.js';
+import StudentsList from '../components/StudentsList.js';
 
 
 let indexRoutes = [

--- a/src/views/Instructors/Assignments.js
+++ b/src/views/Instructors/Assignments.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import Paper from "@material-ui/core/Paper";
-import AssignmentList from '../components/AssignmentList.js';
+import AssignmentList from '../../components/AssignmentList.js';
 import Typography from '@material-ui/core/Typography';
 
 class Assignments extends Component {

--- a/src/views/Instructors/Feedback.js
+++ b/src/views/Instructors/Feedback.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import MarkdownFeedback from "../components/MarkdownFeedback";
+import MarkdownFeedback from "../../components/MarkdownFeedback";
 // import PropTypes from 'prop-types';
 
 class Feedback extends Component {

--- a/src/views/Instructors/Homepage.jsx
+++ b/src/views/Instructors/Homepage.jsx
@@ -1,8 +1,8 @@
 import React, { Component } from 'react';
 // import PropTypes from 'prop-types';
 import {Grid, Paper} from '@material-ui/core';
-import Classroom from '../components/Classroom.js'
-import Cohort from '../components/Cohort.js'
+import Classroom from '../../components/Classroom.js'
+import Cohort from '../../components/Cohort.js'
 
 
 class Homepage extends Component {

--- a/src/views/Students/Classmates.js
+++ b/src/views/Students/Classmates.js
@@ -1,0 +1,23 @@
+import React, { Component } from 'react';
+import Paper from "@material-ui/core/Paper";
+import StudentsList from '../../components/AssignmentList.js';
+import Typography from '@material-ui/core/Typography';
+
+class Classmates extends Component {
+  render() {
+     return (
+         <section>
+          <Typography variant="title" id="tableTitle">
+            Your (logged-in student) classroom Adies...
+          </Typography>
+           <Paper > <StudentsList /> </Paper>
+         </section>
+
+    );
+  }
+}
+
+export default Classmates;
+
+// TODO: send current logged in student cohort/classroom as props in order to decide 
+// which list of students to show (handle it with redux)

--- a/src/views/StudentsList.js
+++ b/src/views/StudentsList.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 // import PropTypes from 'prop-types';
 import Student from '../components/Student.js'
-import StudentProfile from '../components/StudentProfile.js'
 
 // For Redux:
 import {connect} from 'react-redux';
@@ -66,7 +65,7 @@ class StudentsList extends Component {
     return (
     <section style={styles.root}>
     <Typography style={{marginBottom: 20}} variant="title" id="tableTitle">
-      Students on Classroom {this.props.cohort}
+      Students on Classroom {this.props.classroomName}
     </Typography>
 
     <Paper >
@@ -103,7 +102,7 @@ function mapStateToProps(state) {
       return {
       studentsList: state.studentsList,
       currentClassroomStudents: state.currentClassroomStudents,
-      cohort: state.cohort
+      classroomName: state.currentClassroomName
       }
   }
   

--- a/src/views/StudentsList.js
+++ b/src/views/StudentsList.js
@@ -27,9 +27,12 @@ class StudentsList extends Component {
     }
       
     renderStudentList = () => {
-    console.log('studentsList in renderAssignmentList: ' )
+    console.log('studentsList in renderStudenttList: ' )
     console.log(this.props.studentsList)
-     return this.props.studentsList.map((student,index) => {
+    console.log(this.props.currentClassroomStudents)
+        return this.props.currentClassroomStudents.map((student,index) => {
+        //  To change it for ALL STUDENTS LIST, swap this two lines:
+        //  return this.props.studentsList.map((student,index) => {
         return (
             <Student
                 key={index}
@@ -63,7 +66,7 @@ class StudentsList extends Component {
     return (
     <section style={styles.root}>
     <Typography style={{marginBottom: 20}} variant="title" id="tableTitle">
-      Students
+      Students on Classroom {this.props.cohort}
     </Typography>
 
     <Paper >
@@ -98,7 +101,9 @@ function mapStateToProps(state) {
     console.log('function mapStateToProps:' )
       console.log(state.studentsList)
       return {
-      studentsList: state.studentsList
+      studentsList: state.studentsList,
+      currentClassroomStudents: state.currentClassroomStudents,
+      cohort: state.cohort
       }
   }
   

--- a/src/views/StudentsList.js
+++ b/src/views/StudentsList.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 // import PropTypes from 'prop-types';
 import Student from '../components/Student.js'
+import StudentProfile from '../components/StudentProfile.js'
 
 // For Redux:
 import {connect} from 'react-redux';
@@ -33,7 +34,8 @@ class StudentsList extends Component {
             <Student
                 key={index}
                 type={student.type}
-                onClick={()=> window.open("https://github.com/" + student.github_name, "_blank")}
+                // onClick={()=> this.openProfile(student)}
+                openGitHubProfile={()=> window.open("https://github.com/" + student.github_name, "_blank")}
                 name={student.name}
                 email={student.email} 
                 classroom={student.classroom_id}
@@ -81,6 +83,8 @@ class StudentsList extends Component {
         </TableBody>
       </Table>
     </Paper>
+
+    
     </section>
     )
   }


### PR DESCRIPTION
1. Renders _studentList_ based on the current classroom on _state_.

2. Adds _currentClassroomName_ and _currentClassroomId_ to _state_ to handle displaying it across tables titles and etc. 
This caused the Material-UI dropdown menu component to not display classroom because of different value than the ones in the menu items. (Fix later)
4. Adds Student info pop-up modal on _StudentList_ when clicked on.
5. Adds _currentCohort_ and _currentClassroom_ to be set as the last one of the list retrieved from Api call upon mounting of the App component.
6.  Rearranges views folders to **separate** students-views from instructors-views.
7. DRYs up Material-UI imports and combines all of them into one single file. (/components-info/MaterialUiImports)
8. Organizes routes by moving links from MiniDrawer (for the SideBar) to its own component. 
This adds one file for SidebarStudentsLinksList and one file for _SidebarInstructorsLinksList_. 
Needs to arrange what to be available for display when login is implemented.

